### PR TITLE
Add docs for quick start and alternative platform integration

### DIFF
--- a/AGENT-GUIDELINES.md
+++ b/AGENT-GUIDELINES.md
@@ -24,6 +24,7 @@ All Agent3D resources are accessed from `~/.agent3d`. This file (`~/.agent3d/AGE
 
 **Project Setup**: Configure project with `.agent3d-config.yml` in project root
 **DDD Pass**: Execute Scan → Draft → Ask → Sync, then commit with `DDD: <description>`
+**Getting Started**: New users can follow the [Quick Start Guide](docs/QUICK-START.md) for a short introduction.
 
 ### DDD Passes
 
@@ -106,6 +107,7 @@ All Agent3D resources are accessed from `~/.agent3d`. This file (`~/.agent3d/AGE
 3. Follow `~/.agent3d/AGENT-GUIDELINES.md` (this file)
 4. Run DDD pass for missing/outdated documentation
 5. Favor integration tests over mocks
+6. **Update Guidelines Regularly:** Run `git -C ~/.agent3d pull origin main` to keep cached rules and templates current
 
 **Mental Memory Map Creation:**
 - **CRITICAL**: Before starting any work, create a comprehensive mental map of the Agent3D framework and project structure

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ To use Agent3D in your LLM agent:
 3. **Speed Execution**: Use memory-cached patterns to minimize file lookups during pass execution
 4. Follow the DDD passes in sequence for each development task
 
+## Quick Start
+
+If you are new to Agent3D, the [Quick Start Guide](docs/QUICK-START.md) provides a short walkthrough of the essential steps: cloning the repository, configuring your project, running the core workflow, and keeping your guidelines synchronized.
+
 ## Agent Guideline Protocol
 
 The Agent Guideline Protocol is the **entry point** for the Agent3D system. It contains the only hardcoded repository URL in the system, which is necessary since agents start without any repository access.
@@ -116,6 +120,8 @@ Additionally, a **Full Pass** encompasses all of the above passes for comprehens
 - **[Advanced Features Guide](docs/ADVANCED-FEATURES.md)**: Sophisticated capabilities and power-user features
 - **[Configuration Guide](docs/CONFIGURATION-GUIDE.md)**: Customization and project-specific settings
 - **[GitHub CLI Integration](docs/GITHUB-CLI-INTEGRATION.md)**: Automated PR review workflows
+- **[Alternative Platform Integration](docs/OTHER-PLATFORMS-INTEGRATION.md)**: Tips for GitLab and Bitbucket users
+- **[Rapid Prototyping Workflow](docs/RAPID-PROTOTYPING.md)**: Experimental features with retroactive documentation
 
 
 

--- a/docs/OTHER-PLATFORMS-INTEGRATION.md
+++ b/docs/OTHER-PLATFORMS-INTEGRATION.md
@@ -1,0 +1,18 @@
+# Alternative Platform Integration
+
+While Agent3D focuses on GitHub CLI workflows, teams using GitLab or Bitbucket can adapt the same principles with their respective command line tools.
+
+## GitLab
+1. Install the [GitLab CLI](https://gitlab.com/gitlab-org/cli) and authenticate with your account.
+2. Use `glab` commands to check merge request status, view diffs, and leave comments.
+3. Mirror the DDD pass workflow by triggering pipelines after each pass and ensuring documentation stays in sync with merge requests.
+
+## Bitbucket
+1. Use [Bitbucket's REST API](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/) or `bb` command line tools if available.
+2. Check pull request status, add comments, and enforce documentation updates before merges.
+3. Incorporate Bitbucket Pipelines to run tests and documentation validation for each pass.
+
+## General Tips
+- Maintain the same commit conventions and DDD pass sequence regardless of platform.
+- Ensure CI pipelines validate that documentation and code remain aligned.
+- Update your platform-specific configuration in `.agent3d-config.yml` if custom hooks or scripts are required.

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -1,0 +1,36 @@
+# Quick Start Guide
+
+This guide provides a streamlined introduction for new users of the Agent3D framework. It summarizes the minimum steps required to begin using the Documentation-Driven Development workflow.
+
+## 1. Clone Agent3D
+1. Clone the Agent3D repository to `~/.agent3d`:
+   ```bash
+   git clone git@github.com:ningsuhen/agent3d.git ~/.agent3d
+   ```
+2. Keep the repository up to date:
+   ```bash
+   git -C ~/.agent3d pull origin main
+   ```
+
+## 2. Configure Your Project
+1. Run the Foundation Pass to create `.agent3d-config.yml` in your project root.
+2. Adjust the configuration to match your project's language and quality requirements.
+
+## 3. Follow the Core Workflow
+Execute the simplified DDD workflow for each development task:
+1. **Scan** – Identify missing or outdated documentation.
+2. **Draft** – Update or create the necessary docs.
+3. **Ask** – Clarify open questions with stakeholders.
+4. **Sync** – Implement code that matches the documentation.
+
+Commit documentation and code together. If a commit does not update docs, include the `docs-n/a` tag in the commit message.
+
+## 4. Run Tests and Validate
+Use language‑specific tests and linting to verify that code matches documented requirements. The testing pass ensures quality and alignment.
+
+## 5. Maintain Synchronization
+Regularly pull updates from `~/.agent3d` to keep rules and templates current. Re-run relevant passes whenever documentation or code drifts out of sync.
+
+---
+
+For more detailed procedures and advanced configuration options, see the [Configuration Guide](CONFIGURATION-GUIDE.md) and [Common Procedures](COMMON-PROCEDURES.md).

--- a/docs/RAPID-PROTOTYPING.md
+++ b/docs/RAPID-PROTOTYPING.md
@@ -1,0 +1,18 @@
+# Rapid Prototyping Workflow
+
+Sometimes teams need to experiment quickly before full documentation is written. Agent3D supports an optional workflow for this scenario.
+
+1. **Prototype Branch**
+   - Create a dedicated branch prefixed with `prototype/`.
+   - Mark commits with the `experimental` tag to indicate temporary work.
+2. **Minimal Documentation**
+   - Record a brief description of the experiment in `docs/proposals/`.
+   - Capture decisions and assumptions as they emerge.
+3. **Retrospective Documentation**
+   - Once the prototype proves valuable, expand the documentation to full Agent3D standards.
+   - Run the Documentation Pass followed by Implementation and Testing Passes to bring the prototype into alignment.
+4. **Cleanup**
+   - Remove experimental branches that are no longer needed.
+   - Ensure `docs/DDD-STATUS.md` reflects the updated state.
+
+This workflow allows controlled experimentation without sacrificing the core principle that documentation leads production code.


### PR DESCRIPTION
## Summary
- add Quick Start guide for new users
- crosslink Quick Start in AGENT-GUIDELINES and README
- add doc on adapting DDD to GitLab or Bitbucket
- outline optional rapid prototyping workflow
- mention regular guideline updates

## Testing
- `git status --short`
